### PR TITLE
Mirror of NagiosEnterprises nagioscore#645

### DIFF
--- a/t-tap/test_checks.c
+++ b/t-tap/test_checks.c
@@ -1473,6 +1473,7 @@ void run_misc_service_check_tests()
 
 void run_reaper_tests()
 {
+    int result;
     /* test null dir */
     my_free(check_result_path);
     check_result_path = NULL;
@@ -1485,35 +1486,43 @@ void run_reaper_tests()
         "cant open check result path is an error");
     my_free(check_result_path);
 
+    /* Allow the check reaper to take awhile */
+    max_check_reaper_time = 10;
+
     /* existing dir, with nothing in it */
     check_result_path = nspath_absolute("./../t-tap/var/reaper/no_files", NULL);
-    ok(process_check_result_queue(check_result_path) == 0,
-        "0 files (as there shouldn't be)");
+    result = process_check_result_queue(check_result_path);
+    ok(result == 0,
+        "%d files processed, expected 0 files", result);
     my_free(check_result_path);
 
     /* existing dir, with 2 check files in it */
     create_check_result_file(1, "hst1", "svc1", "output");
     create_check_result_file(2, "hst1", NULL, "output");
     check_result_path = nspath_absolute("./../t-tap/var/reaper/some_files", NULL);
-    ok(process_check_result_queue(check_result_path) == 2,
-        "2 files (as there should be)");
+    result = process_check_result_queue(check_result_path);
+    ok(result == 2,
+        "%d files processed, expected 2 files", result);
     my_free(check_result_path);
     test_check_debugging=FALSE;
 
     /* do sig_{shutdown,restart} work as intended */
     sigshutdown = TRUE;
     check_result_path = nspath_absolute("./../t-tap/var/reaper/some_files", NULL);
-    ok(process_check_result_queue(check_result_path) == 0,
-        "0 files (as there shouldn't be)");
+    result = process_check_result_queue(check_result_path);
+    ok(result == 0,
+        "%d files processed, expected 0 files", result);
     sigshutdown = FALSE;
     sigrestart = TRUE;
-    ok(process_check_result_queue(check_result_path) == 0,
-        "0 files (as there shouldn't be)");
+    result = process_check_result_queue(check_result_path);
+    ok(result == 0,
+        "%d files processed, expected 0 files", result);
 
     /* force too long of a check */
     max_check_reaper_time = -5;
     sigrestart = FALSE;
-    ok(process_check_result_queue(check_result_path) == 0,
+    result = process_check_result_queue(check_result_path);
+    ok(result == 0,
         "cant process if taking too long");
     my_free(check_result_path);
 


### PR DESCRIPTION
Mirror of NagiosEnterprises nagioscore#645
This test (line ~1500 in test_checks) seemed to break ~50% of the time when run against ~8 compilers concurrently, possibly due to a race condition on the directory where data was being stored. ~The test has been changed so that each test will write to a different directory, so long as they call gettimeofday() on different microseconds.~

EDIT: I was wrong about why this was happening. The actual issue was that the default timeout (max_check_reaper_time) wasn't getting initialized in the test code. This is fixed in the force-pushed code shown below
