### PR TITLE
Mirror of NagiosEnterprises nagioscore#672

### DIFF
--- a/html/main.php
+++ b/html/main.php
@@ -26,7 +26,7 @@ $this_year = '2019';
 						"Click here to watch the entire Nagios Core 4 Tour!</a>";
 	<?php } ?>
 	$(document).ready(function() {
-		var user = "<?php echo $_SERVER['REMOTE_USER']; ?>";
+		var user = "<?php echo htmlspecialchars($_SERVER['REMOTE_USER']); ?>";
 
 		<?php if ($cfg["enable_page_tour"]) { ?>
 			vBoxId += ";" + user;


### PR DESCRIPTION
Mirror of NagiosEnterprises nagioscore#672
The $_SERVER['REMOTE_USER'] isn't sanitized prior to being echoed out which results in a XSS (though this would be difficult for an attacker to reproduce due to needing access to the users file).
 
To reproduce, add new user to: /usr/local/nagiosxi/etc/htpasswd.users
with username: <script>alert(document.cookie)</script> and reload the page resulting in the cookie being displayed.
