### PR TITLE
Mirror of NagiosEnterprises nagioscore#666

### DIFF
--- a/base/nagios.c
+++ b/base/nagios.c
@@ -902,6 +902,8 @@ int main(int argc, char **argv) {
 			/* try and collect any zombie processes */
 			if (sigrestart == TRUE) {
 
+				sleep(1);
+
 				int status = 0;
 				pid_t child_pid;
 				log_debug_info(DEBUGL_PROCESS, 1, "Calling waitpid() on all children...\n");


### PR DESCRIPTION
Mirror of NagiosEnterprises nagioscore#666
Forgot to PR this earlier. Resolves #441 and #620. 

I don't particularly like this as a fix, but was talking to <at>hedenface about it some time ago and he mentioned that the race condition here was more-or-less inherent to how POSIX signals work, and that the "right fix" was simply waiting so that the process would have time to terminate AND send a SIGCHLD before the main thread tries to collect them (as I had already done).
