### PR TITLE
Mirror of NagiosEnterprises nagioscore#663

### DIFF
--- a/lib/worker.c
+++ b/lib/worker.c
@@ -215,7 +215,7 @@ int worker_buf2kvvec_prealloc(struct kvvec *kvv, char *buf, unsigned long len, i
 	} while (0)
 
 /* forward declaration */
-static void gather_output(child_process *cp, iobuf *io, int final);
+static int gather_output(child_process *cp, iobuf *io, int final);
 
 static void destroy_job(child_process *cp)
 {
@@ -262,8 +262,15 @@ int finish_job(child_process *cp, int reason)
 
 	/* get rid of still open filedescriptors */
 	if (cp->outstd.fd != -1) {
-		gather_output(cp, &cp->outstd, 1);
-		iobroker_close(iobs, cp->outstd.fd);
+		int keep_going = 1;
+		int rd;
+		while(keep_going) {
+			log_debug_info(16, 0, "Still going, keep_going is %d", keep_going);
+			rd = gather_output(cp, &cp->outstd, 0);
+			log_debug_info(16, 0, "Finishing job - read another %d bytes!\n", rd);
+			keep_going = rd > 0;
+		}
+		//iobroker_close(iobs, cp->outstd.fd);
 	}
 	if (cp->outerr.fd != -1) {
 		gather_output(cp, &cp->outerr, 1);
@@ -442,13 +449,13 @@ static void kill_job(child_process *cp, int reason)
 	destroy_job(cp);
 }
 
-static void gather_output(child_process *cp, iobuf *io, int final)
+static int gather_output(child_process *cp, iobuf *io, int final)
 {
 	int retry = 5;
+	int rd;
 
 	for (;;) {
 		char buf[4096];
-		int rd;
 
 		rd = read(io->fd, buf, sizeof(buf));
 		if (rd < 0) {
@@ -484,13 +491,13 @@ static void gather_output(child_process *cp, iobuf *io, int final)
 		if (rd <= 0 || final) {
 			iobroker_close(iobs, io->fd);
 			io->fd = -1;
-			if (!final)
-				check_completion(cp, WNOHANG);
 			break;
 		}
 
 		break;
 	}
+
+	return rd;
 }
 
 

--- a/lib/worker.c
+++ b/lib/worker.c
@@ -258,22 +258,23 @@ static void destroy_job(child_process *cp)
 int finish_job(child_process *cp, int reason)
 {
 	static struct kvvec resp = KVVEC_INITIALIZER;
-	int i, ret;
+	int i, ret, rd;
 
 	/* get rid of still open filedescriptors */
 	if (cp->outstd.fd != -1) {
-		int keep_going = 1;
-		int rd;
-		while(keep_going) {
-			log_debug_info(16, 0, "Still going, keep_going is %d", keep_going);
+
+		rd = 1;
+		while(rd > 0) {
 			rd = gather_output(cp, &cp->outstd, 0);
-			log_debug_info(16, 0, "Finishing job - read another %d bytes!\n", rd);
-			keep_going = rd > 0;
 		}
-		//iobroker_close(iobs, cp->outstd.fd);
+		iobroker_close(iobs, cp->outstd.fd);
 	}
 	if (cp->outerr.fd != -1) {
-		gather_output(cp, &cp->outerr, 1);
+
+		rd = 1;
+		while(rd > 0) {
+			rd = gather_output(cp, &cp->outerr, 0);
+		}
 		iobroker_close(iobs, cp->outerr.fd);
 	}
 


### PR DESCRIPTION
Mirror of NagiosEnterprises nagioscore#663
#625 

Plugin output was getting cut off when worker's SIGCHLD handler fired before iobroker had finished polling the plugin's output. When sigchld handler fires, make sure to retrieve all output.
