### PR TITLE
Mirror of NagiosEnterprises nagioscore#722

### DIFF
--- a/t-tap/test_checks.c
+++ b/t-tap/test_checks.c
@@ -66,7 +66,7 @@
 
 #define NO_SERVICE      0,0,NULL
 
-int date_format;
+extern int date_format;
 int test_check_debugging = FALSE;
 
 service         * svc1          = NULL;

--- a/t-tap/test_commands.c
+++ b/t-tap/test_commands.c
@@ -60,25 +60,23 @@
 #include "tap.h"
 
 char *temp_path;
-int date_format;
+extern int date_format;
 host *host_list;
 service *service_list;
-int accept_passive_service_checks;
 int check_host_freshness;
 int check_service_freshness;
-int check_external_commands;
+extern int check_external_commands;
 unsigned long modified_host_process_attributes;
 unsigned long modified_service_process_attributes;
-int enable_notifications;
-int obsess_over_hosts;
-int obsess_over_services;
-int execute_service_checks;
-int enable_event_handlers;
-int accept_passive_host_checks;
-int accept_passive_service_checks;
-int process_performance_data;
-int execute_host_checks;
-int execute_service_checks;
+extern int enable_notifications;
+extern int obsess_over_hosts;
+extern int obsess_over_services;
+extern int execute_service_checks;
+extern int enable_event_handlers;
+extern int accept_passive_host_checks;
+extern int accept_passive_service_checks;
+extern int process_performance_data;
+extern int execute_host_checks;
 char *global_service_event_handler;
 command *global_service_event_handler_ptr;
 char *global_host_event_handler;

--- a/t-tap/test_logging.c
+++ b/t-tap/test_logging.c
@@ -26,7 +26,6 @@
 
 #define TEST_LOGGING 1
 
-int date_format                     = 0;
 char *log_file                      = NULL;
 int verify_config                   = FALSE;
 int test_scheduling                 = FALSE;

--- a/xdata/xsddefault.c
+++ b/xdata/xsddefault.c
@@ -38,22 +38,22 @@
 
 #ifdef NSCGI
 #include "../include/cgiutils.h"
-time_t program_start;
-int daemon_mode;
-time_t last_log_rotation;
-int enable_notifications;
-int execute_service_checks;
-int accept_passive_service_checks;
-int execute_host_checks;
-int accept_passive_host_checks;
-int enable_event_handlers;
-int obsess_over_services;
-int obsess_over_hosts;
+extern time_t program_start;
+extern int daemon_mode;
+extern time_t last_log_rotation;
+extern int enable_notifications;
+extern int execute_service_checks;
+extern int accept_passive_service_checks;
+extern int execute_host_checks;
+extern int accept_passive_host_checks;
+extern int enable_event_handlers;
+extern int obsess_over_services;
+extern int obsess_over_hosts;
 int check_service_freshness;
 int check_host_freshness;
-int enable_flap_detection;
-int process_performance_data;
-int nagios_pid;
+extern int enable_flap_detection;
+extern int process_performance_data;
+extern int nagios_pid;
 int buffer_stats[1][3];
 int program_stats[MAX_CHECK_STATS_TYPES][3];
 #endif


### PR DESCRIPTION
Mirror of NagiosEnterprises nagioscore#722
I was stabbing in the dark here, but this passes a
```
./configure --enable-libtap --enable-event-broker && make all && make test
```
so it must be correct. That's how this works, right?
